### PR TITLE
Update python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,50 +1,62 @@
-# GitHub Actions Workflow: Publish Python Package on Release
-# This workflow will automatically upload the Python package to PyPI when a release is published.
-# Refer to GitHub's documentation for further details: 
-# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
-# Note:
-# This workflow uses third-party actions provided by the community. Please review their terms of service,
-# privacy policies, and support documentation as they are not governed by GitHub.
-
-name: Upload Python Package
+name: CI/CD Pipeline for Hugging Face Space Deployment
 
 on:
-  release:
-    types: [published]  # Trigger only when a release is published
-
-permissions:
-  contents: read  # Minimal permissions for accessing release contents
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest  # Specify the latest Ubuntu environment
+  build:
+    runs-on: ubuntu-latest
 
     steps:
-      # Step 1: Check out the repository
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-      # Step 2: Set up Python environment
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
           python-version: '3.x'  # Specify compatible Python version (adjust as needed)
 
-      # Step 3: Install dependencies for building the package
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install build
 
-      # Step 4: Build the Python package
-      - name: Build package
-        run: python -m build
+      - name: Build for deployment
+        run: python -m build  # Assuming build.py builds the distributable
 
-      # Step 5: Publish the package to PyPI
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to Hugging Face Hub
+        uses: actions/github-script@v6
         with:
-          user: __token__  # PyPI username for token-based authentication
-          password: ${{ secrets.PYPI_API_TOKEN }}  # Securely access the PyPI API token stored in GitHub Secrets
+          script: |
+            github.rest.repos.createOrUpdateFileContents({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: '.env',
+              message: 'Update Hugging Face Hub API token',
+              content: Buffer.from(`HF_TOKEN=${process.env.HUGGING_FACE_TOKEN}`).toString('base64'),
+              branch: 'main'
+            })
 
+      - name: Install dependencies (for deployment process)
+        run: npm install  # Assuming some npm packages are required for deployment
+
+      - name: Deploy to Hugging Face Spaces
+        uses: huggingface/actions/cli/v2
+        with:
+          repo_id: <your-huggingface-username>/<your-space-name> 
+          commit_message: "Deploy from GitHub Actions"
+          build_dir: "dist"  # Assuming build.py creates a dist directory


### PR DESCRIPTION
This YAML code merges the functionality of the two provided workflows while tailoring it for deploying a Python package to Hugging Face Spaces.

Key changes and explanations:

Combined Purpose: The workflow name now reflects the deployment purpose for Hugging Face Spaces. Build Step: The build step uses python -m build assuming a build.py script handles building the distributable package. Adjust this command based on your build process. Separate Dependencies: The deployment job has a separate Install dependencies step assuming additional npm packages are needed for deployment. Removed Unnecessary Steps: Steps related to publishing a Python package to PyPI are removed as they're not relevant for Hugging Face Space deployment. Kept Essential Steps: Steps for checking out code, setting up Python environment, logging in to Hugging Face Hub, and deploying the build directory are retained. Remember to replace <your-huggingface-username> and <your-space-name> with your actual details.